### PR TITLE
Loads contributors from server action to components instead of contrib.rocks as a static image.

### DIFF
--- a/app/projects/[slug]/[[...tab]]/page.tsx
+++ b/app/projects/[slug]/[[...tab]]/page.tsx
@@ -1,6 +1,8 @@
 import ProjectAnalytics from "@/components/projects/project-analytics";
 import { PROJECT_TABS } from "@/components/projects/project-constants";
+import { Contribs } from "@/components/projects/project-contribs";
 import ProjectTeam from "@/components/projects/project-team";
+import { getContribs } from "@/lib/actions/get-contribs";
 import { getProject } from "@/lib/actions/get-project";
 import { notFound } from "next/navigation";
 
@@ -37,15 +39,13 @@ export default async function Project({
     return <ProjectTeam project={project} />;
   }
 
+  const split = project.githubLink.url.split("/");
+  const repo = split.pop();
+  const owner = split.pop();
+
+  const contribs = await getContribs(owner, repo);
+
   if (tab[0] === "contributors") {
-    return (
-      <a href={project.githubLink.shortLink} target="_blank">
-        <img
-          src={`https://contrib.rocks/image?repo=${
-            project.githubLink.url.split("https://github.com/")[1]
-          }`}
-        />
-      </a>
-    );
+    return <Contribs contribs={contribs} />;
   }
 }

--- a/components/projects/project-constants.ts
+++ b/components/projects/project-constants.ts
@@ -1,11 +1,11 @@
 export const PROJECT_TABS = [
   {
-    title: "Team",
-    tab: "team",
-  },
-  {
     title: "Contributors",
     tab: "contributors",
+  },
+  {
+    title: "Team",
+    tab: "team",
   },
 ];
 

--- a/components/projects/project-contribs.tsx
+++ b/components/projects/project-contribs.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { ContribInfo } from "@/lib/actions/get-contribs";
+import { Github } from "@dub/ui";
 import { cn } from "@dub/utils";
 import { motion } from "framer-motion";
 import Image from "next/image";
-import Link from "next/link";
 import { useState } from "react";
 export function Contribs({
   contribs,
@@ -47,7 +47,12 @@ export function Contrib({ info }: { info: ContribInfo }) {
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
     >
-      <Link key={info.id} className="flex items-center" href={info.html_url}>
+      <a
+        key={info.id}
+        className="flex items-center"
+        href={info.html_url}
+        target="_blank"
+      >
         <motion.div
           variants={{
             initial: { scale: 1 },
@@ -70,7 +75,7 @@ export function Contrib({ info }: { info: ContribInfo }) {
           />
         </motion.div>
         <motion.div
-          className="absolute left-1/2 rounded-lg border border-white/60 bg-white/80 px-2 text-center drop-shadow-sm backdrop-blur-[2px]"
+          className="absolute left-1/2 flex min-w-[6rem] flex-col items-center justify-center rounded-xl border border-gray-200 bg-white p-2 text-center shadow-md"
           variants={{
             hidden: { opacity: 0, scale: 0, translateX: "-50%", top: "50%" },
             visible: { opacity: 1, scale: 1, translateX: "-50%", top: "100%" },
@@ -83,9 +88,10 @@ export function Contrib({ info }: { info: ContribInfo }) {
             damping: 18,
           }}
         >
-          <span className="text-lg">{info.login}</span>
+          <Github className="inline-block h-4 w-4" />
+          <span className="text-gray-600">{info.login}</span>
         </motion.div>
-      </Link>
+      </a>
     </motion.div>
   );
 }

--- a/components/projects/project-contribs.tsx
+++ b/components/projects/project-contribs.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { ContribInfo } from "@/lib/actions/get-contribs";
+import { cn } from "@dub/utils";
+import { motion } from "framer-motion";
+import Image from "next/image";
+import Link from "next/link";
+import { useState } from "react";
+export function Contribs({
+  contribs,
+  className,
+  renderContrib,
+}: {
+  contribs: ContribInfo[];
+  className?: string;
+  renderContrib?: (contrib: ContribInfo) => React.ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-wrap items-center justify-center gap-2",
+        className,
+      )}
+    >
+      {contribs.map((contrib, i) => {
+        if (renderContrib) {
+          return renderContrib(contrib);
+        }
+        return <Contrib key={i} info={contrib} />;
+      })}
+    </div>
+  );
+}
+
+export function Contrib({ info }: { info: ContribInfo }) {
+  const [hover, setHover] = useState(false);
+
+  return (
+    <motion.div
+      variants={{
+        initial: { zIndex: 0 },
+        hover: { zIndex: 100 },
+      }}
+      initial="initial"
+      animate={hover ? "hover" : "initial"}
+      className=" relative drop-shadow-2xl"
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+    >
+      <Link key={info.id} className="flex items-center" href={info.html_url}>
+        <motion.div
+          variants={{
+            initial: { scale: 1 },
+            hover: { scale: 1.5 },
+          }}
+          initial="initial"
+          animate={hover ? "hover" : "initial"}
+          transition={{
+            type: "spring",
+            stiffness: 500,
+            damping: 25,
+          }}
+        >
+          <Image
+            src={info.avatar_url}
+            alt={info.login}
+            width={48}
+            height={48}
+            className="rounded-full"
+          />
+        </motion.div>
+        <motion.div
+          className="absolute left-1/2 rounded-lg border border-white/60 bg-white/80 px-2 text-center drop-shadow-sm backdrop-blur-[2px]"
+          variants={{
+            hidden: { opacity: 0, scale: 0, translateX: "-50%", top: "50%" },
+            visible: { opacity: 1, scale: 1, translateX: "-50%", top: "100%" },
+          }}
+          initial="hidden"
+          animate={hover ? "visible" : "hidden"}
+          transition={{
+            type: "spring",
+            stiffness: 260,
+            damping: 18,
+          }}
+        >
+          <span className="text-lg">{info.login}</span>
+        </motion.div>
+      </Link>
+    </motion.div>
+  );
+}

--- a/components/projects/project-layout-tabs.tsx
+++ b/components/projects/project-layout-tabs.tsx
@@ -32,7 +32,7 @@ export default function ProjectLayoutTabs() {
           ? tab[0] === "team"
             ? `Active team members of the project. View the full list on [GitHub](${props.githubLink.shortLink}).`
             : tab[0] === "contributors"
-              ? `Top contributors of the project – powered by [contrib.rocks](https://contrib.rocks). View the full list on [GitHub](${props.githubLink.shortLink}).`
+              ? `Top contributors of the project. View the full list on [GitHub](${props.githubLink.shortLink}).`
               : ""
           : "Real-time click analytics for each of the links above – powered by the [Dub API](https://dub.co/api)."}
       </ProjectTabNote>

--- a/lib/actions/get-contribs.ts
+++ b/lib/actions/get-contribs.ts
@@ -1,5 +1,6 @@
 "use server";
-import { Octokit } from "@octokit/rest";
+
+import { octokit } from "../github";
 
 export interface ContribInfo {
   login: string;
@@ -24,10 +25,6 @@ export interface ContribInfo {
 }
 
 export async function getContribs(owner: string, repo: string) {
-  const octokit = new Octokit({
-    auth: process.env.GITHUB_OAUTH_TOKEN,
-  });
-
   const res = await octokit.repos.listContributors({
     owner,
     repo,

--- a/lib/actions/get-contribs.ts
+++ b/lib/actions/get-contribs.ts
@@ -1,0 +1,38 @@
+"use server";
+import { Octokit } from "@octokit/rest";
+
+export interface ContribInfo {
+  login: string;
+  id: number;
+  node_id: string;
+  avatar_url: string;
+  gravatar_id: string;
+  url: string;
+  html_url: string;
+  followers_url: string;
+  following_url: string;
+  gists_url: string;
+  starred_url: string;
+  subscriptions_url: string;
+  organizations_url: string;
+  repos_url: string;
+  events_url: string;
+  received_events_url: string;
+  type: string;
+  site_admin: boolean;
+  contributions: number;
+}
+
+export async function getContribs(owner: string, repo: string) {
+  const octokit = new Octokit({
+    auth: process.env.GITHUB_OAUTH_TOKEN,
+  });
+
+  const res = await octokit.repos.listContributors({
+    owner,
+    repo,
+    per_page: 100,
+  });
+
+  return res.data as ContribInfo[];
+}

--- a/lib/github.ts
+++ b/lib/github.ts
@@ -1,4 +1,9 @@
 import { GOOGLE_FAVICON_URL } from "@dub/utils";
+import { Octokit } from "@octokit/rest";
+
+export const octokit = new Octokit({
+  auth: process.env.GITHUB_OAUTH_TOKEN,
+});
 
 export async function getRepo(url: string) {
   const repo = url.replace("https://github.com/", "");

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@dub/utils": "^0.0.48",
     "@headlessui/tailwindcss": "^0.2.0",
     "@hookform/resolvers": "^3.3.4",
+    "@octokit/rest": "^20.1.0",
     "@prisma/client": "^4.16.2",
     "@sindresorhus/slugify": "^2.2.1",
     "@tremor/react": "^3.16.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   '@hookform/resolvers':
     specifier: ^3.3.4
     version: 3.3.4(react-hook-form@7.51.3)
+  '@octokit/rest':
+    specifier: ^20.1.0
+    version: 20.1.0
   '@prisma/client':
     specifier: ^4.16.2
     version: 4.16.2(prisma@4.16.2)
@@ -689,6 +692,119 @@ packages:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
+
+  /@octokit/auth-token@4.0.0:
+    resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
+    engines: {node: '>= 18'}
+    dev: false
+
+  /@octokit/core@5.2.0:
+    resolution: {integrity: sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/auth-token': 4.0.0
+      '@octokit/graphql': 7.1.0
+      '@octokit/request': 8.4.0
+      '@octokit/request-error': 5.1.0
+      '@octokit/types': 13.4.1
+      before-after-hook: 2.2.3
+      universal-user-agent: 6.0.1
+    dev: false
+
+  /@octokit/endpoint@9.0.5:
+    resolution: {integrity: sha512-ekqR4/+PCLkEBF6qgj8WqJfvDq65RH85OAgrtnVp1mSxaXF03u2xW/hUdweGS5654IlC0wkNYC18Z50tSYTAFw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/types': 13.4.1
+      universal-user-agent: 6.0.1
+    dev: false
+
+  /@octokit/graphql@7.1.0:
+    resolution: {integrity: sha512-r+oZUH7aMFui1ypZnAvZmn0KSqAUgE1/tUXIWaqUCa1758ts/Jio84GZuzsvUkme98kv0WFY8//n0J1Z+vsIsQ==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/request': 8.4.0
+      '@octokit/types': 13.4.1
+      universal-user-agent: 6.0.1
+    dev: false
+
+  /@octokit/openapi-types@20.0.0:
+    resolution: {integrity: sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==}
+    dev: false
+
+  /@octokit/openapi-types@22.1.0:
+    resolution: {integrity: sha512-pGUdSP+eEPfZiQHNkZI0U01HLipxncisdJQB4G//OAmfeO8sqTQ9KRa0KF03TUPCziNsoXUrTg4B2Q1EX++T0Q==}
+    dev: false
+
+  /@octokit/plugin-paginate-rest@9.2.1(@octokit/core@5.2.0):
+    resolution: {integrity: sha512-wfGhE/TAkXZRLjksFXuDZdmGnJQHvtU/joFQdweXUgzo1XwvBCD4o4+75NtFfjfLK5IwLf9vHTfSiU3sLRYpRw==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '5'
+    dependencies:
+      '@octokit/core': 5.2.0
+      '@octokit/types': 12.6.0
+    dev: false
+
+  /@octokit/plugin-request-log@4.0.1(@octokit/core@5.2.0):
+    resolution: {integrity: sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '5'
+    dependencies:
+      '@octokit/core': 5.2.0
+    dev: false
+
+  /@octokit/plugin-rest-endpoint-methods@10.4.1(@octokit/core@5.2.0):
+    resolution: {integrity: sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '5'
+    dependencies:
+      '@octokit/core': 5.2.0
+      '@octokit/types': 12.6.0
+    dev: false
+
+  /@octokit/request-error@5.1.0:
+    resolution: {integrity: sha512-GETXfE05J0+7H2STzekpKObFe765O5dlAKUTLNGeH+x47z7JjXHfsHKo5z21D/o/IOZTUEI6nyWyR+bZVP/n5Q==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/types': 13.4.1
+      deprecation: 2.3.1
+      once: 1.4.0
+    dev: false
+
+  /@octokit/request@8.4.0:
+    resolution: {integrity: sha512-9Bb014e+m2TgBeEJGEbdplMVWwPmL1FPtggHQRkV+WVsMggPtEkLKPlcVYm/o8xKLkpJ7B+6N8WfQMtDLX2Dpw==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/endpoint': 9.0.5
+      '@octokit/request-error': 5.1.0
+      '@octokit/types': 13.4.1
+      universal-user-agent: 6.0.1
+    dev: false
+
+  /@octokit/rest@20.1.0:
+    resolution: {integrity: sha512-STVO3itHQLrp80lvcYB2UIKoeil5Ctsgd2s1AM+du3HqZIR35ZH7WE9HLwUOLXH0myA0y3AGNPo8gZtcgIbw0g==}
+    engines: {node: '>= 18'}
+    dependencies:
+      '@octokit/core': 5.2.0
+      '@octokit/plugin-paginate-rest': 9.2.1(@octokit/core@5.2.0)
+      '@octokit/plugin-request-log': 4.0.1(@octokit/core@5.2.0)
+      '@octokit/plugin-rest-endpoint-methods': 10.4.1(@octokit/core@5.2.0)
+    dev: false
+
+  /@octokit/types@12.6.0:
+    resolution: {integrity: sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==}
+    dependencies:
+      '@octokit/openapi-types': 20.0.0
+    dev: false
+
+  /@octokit/types@13.4.1:
+    resolution: {integrity: sha512-Y73oOAzRBAUzR/iRAbGULzpNkX8vaxKCqEtg6K74Ff3w9f5apFnWtE/2nade7dMWWW3bS5Kkd6DJS4HF04xreg==}
+    dependencies:
+      '@octokit/openapi-types': 22.1.0
+    dev: false
 
   /@panva/hkdf@1.1.1:
     resolution: {integrity: sha512-dhPeilub1NuIG0X5Kvhh9lH4iW3ZsHlnzwgwbOlgwQ2wG1IqFzsgHqmKPk3WzsdWAeaxKJxgM0+W433RmN45GA==}
@@ -1901,6 +2017,10 @@ packages:
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  /before-after-hook@2.2.3:
+    resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
+    dev: false
+
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
@@ -2147,6 +2267,10 @@ packages:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
     dependencies:
       character-entities: 2.0.2
+    dev: false
+
+  /deprecation@2.3.1:
+    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
     dev: false
 
   /dequal@2.0.3:
@@ -3727,6 +3851,10 @@ packages:
       '@types/unist': 3.0.2
       unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.1
+    dev: false
+
+  /universal-user-agent@6.0.1:
+    resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
     dev: false
 
   /update-browserslist-db@1.0.13(browserslist@4.22.1):


### PR DESCRIPTION
I added a file `lib/actions/get-contribs.ts` that contains the server action `getContribs` and the interface `ContribInfo`.

The `getContribs` action loads repo contributors using a [GitHub OAuth Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) and the [@octokit/rest](https://www.npmjs.com/package/@octokit/rest) package.

`getContribs` uses `process.env.GITHUB_OAUTH_TOKEN`.

I also added a file `components/projects/project-contribs.tsx` that has two components in it: `Contribs` and `Contrib`.
- `Contribs` accepts a list of `ContribInfo` and displays `Contrib`s
- `Contrib` is a component that displays the GitHub avatar of the contributor and displays the username on hover. This also serves as a link to the GitHub user.

I also changed `components/projects/project-layout-tabs.tsx` slightly by removing the note that states contributions are powered by [contrib.rocks](https://contrib.rocks).


https://github.com/dubinc/oss-gallery/assets/16091805/dab1154a-4b51-44b4-bbcc-68ff5d8e6602


