### PR TITLE
fix: Edit Project button breaks the UI when there is no Website URL

### DIFF
--- a/components/projects/edit-project-form.tsx
+++ b/components/projects/edit-project-form.tsx
@@ -186,7 +186,7 @@ export default function EditProjectForm({
           <input
             {...register("website")}
             required
-            defaultValue={props.websiteLink.url}
+            defaultValue={props.websiteLink?.url}
             placeholder="https://dub.co"
             className={`${
               errors.website


### PR DESCRIPTION
Clicking the "Edit Project" button breaks the UI when there is no Website URL stored for the project. This occurs due to the presence of `defaultValue={props.websiteLink.url}` in the `components/projects/edit-project-form.tsx` file.

<img width="1507" alt="Screenshot 2024-05-04 at 7 14 32 PM" src="https://github.com/dubinc/oss-gallery/assets/49616121/e2c220e6-a18d-4a5a-89f8-bfb79f866982">

