### PR TITLE
Fix unwanted children movement on project card hover

### DIFF
--- a/components/projects/project-card.tsx
+++ b/components/projects/project-card.tsx
@@ -9,7 +9,7 @@ export default function ProjectCard(project: Project) {
   return (
     <Link
       href={`/projects/${project.slug}`}
-      className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-md transition-all hover:-translate-y-0.5 hover:shadow-xl"
+      className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-md transition-transform will-change-transform hover:-translate-y-0.5 hover:shadow-xl"
     >
       <div
         className={cn(


### PR DESCRIPTION
Hello! Love the OSS Gallery initiative and the project @steven-tey!

This PR fixes annoying children's movement when using a transform scale on an element. Notice the movement of the verified badge icon and GitHub stars icon.

It's a somewhat common issue, mentioned [here](https://github.com/tailwindlabs/tailwindcss/discussions/9910), in the Tailwind CSS repo.

(1) There's no need to `transition-all` because we need to transition only the transformation.
(2) The addition of `will-change-transform` is a must here to prevent layout jumping

## Before
https://github.com/dubinc/oss-gallery/assets/15891813/a3a139fe-d86d-4d30-9ac6-cb987d1ba47d

## After
https://github.com/dubinc/oss-gallery/assets/15891813/560ce74c-e7b0-49de-939d-83d0fe9ef594

